### PR TITLE
remove include term hierarchy parameter from bulk edit terms

### DIFF
--- a/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2023-02-01-preview/examples/Glossary_BulkUpdateGlossaryTerms.json
+++ b/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2023-02-01-preview/examples/Glossary_BulkUpdateGlossaryTerms.json
@@ -1,27 +1,12 @@
 {
   "parameters": {
     "Endpoint": "{Endpoint}",
-    "includeTermHierarchy": true,
     "terms": [
       {
         "guid": "bb64b85a-6497-474b-b407-42121e0c060e",
         "qualifiedName": "ExampleTerm1@ExampleGlossary",
         "name": "ExampleTerm1",
-        "lastModifiedTS": "1",
-        "createdBy": "ServiceAdmin",
-        "updatedBy": "a13d1cbe-a420-4e27-b8cc-252cbe425148",
-        "createTime": 1681377565875,
-        "updateTime": 1681787549486,
         "nickName": "ExampleTerm1",
-        "hierarchyInfo": [
-          {
-            "guid": "bb64b85a-6497-474b-b407-42121e0c060e",
-            "typeName": "AtlasGlossaryTerm",
-            "properties": {
-              "nickName": "ExampleTerm1"
-            }
-          }
-        ],
         "anchor": {
           "glossaryGuid": "4605a852-9a24-4f59-bdc4-49874bc70c16",
           "relationGuid": "28d4f77b-9792-49ff-88c8-da7ade7bc6b5"
@@ -58,21 +43,7 @@
         "guid": "a3c09dcf-844c-49a5-81a8-be95b01177cd",
         "qualifiedName": "ExampleTerm2@ExampleGlossary",
         "name": "ExampleTerm2",
-        "lastModifiedTS": "1",
-        "createdBy": "ServiceAdmin",
-        "updatedBy": "a13d1cbe-a420-4e27-b8cc-252cbe425148",
-        "createTime": 1681377592888,
-        "updateTime": 1681787549486,
         "nickName": "ExampleTerm2",
-        "hierarchyInfo": [
-          {
-            "guid": "a3c09dcf-844c-49a5-81a8-be95b01177cd",
-            "typeName": "AtlasGlossaryTerm",
-            "properties": {
-              "nickName": "ExampleTerm2"
-            }
-          }
-        ],
         "anchor": {
           "glossaryGuid": "4605a852-9a24-4f59-bdc4-49874bc70c16",
           "relationGuid": "b458f7f2-ceea-461c-a412-47224ff52056"

--- a/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2023-02-01-preview/purviewcatalog.json
+++ b/specification/purview/data-plane/Azure.Analytics.Purview.Catalog/preview/2023-02-01-preview/purviewcatalog.json
@@ -3919,9 +3919,6 @@
         },
         "parameters": [
           {
-            "$ref": "#/parameters/includeTermHierarchy"
-          },
-          {
             "in": "body",
             "name": "terms",
             "description": "An array of terms to update.",


### PR DESCRIPTION
Remove include term hierarchy parameter from bulk edit terms and remove unnecessary part of bulk edit terms request payload

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.
